### PR TITLE
Add initClass false to download Groovy libraries at runtime

### DIFF
--- a/authoring/scripts/rest/plugins/org/rd/plugin/openai/openai/gentext.get.groovy
+++ b/authoring/scripts/rest/plugins/org/rd/plugin/openai/openai/gentext.get.groovy
@@ -1,5 +1,4 @@
-@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1')
-
+@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1', initClass=false)
 
 import com.theokanning.openai.OpenAiService
 import com.theokanning.openai.completion.CompletionRequest
@@ -21,5 +20,5 @@ CompletionRequest completionRequest = CompletionRequest.builder()
         .user("russ.danner@craftercms.com")
         .maxTokens(100)
         .build()
-                
+
 return service.createCompletion(completionRequest).getChoices()

--- a/authoring/scripts/rest/plugins/org/rd/plugin/textgen/textgen/gentext.get.groovy
+++ b/authoring/scripts/rest/plugins/org/rd/plugin/textgen/textgen/gentext.get.groovy
@@ -1,4 +1,4 @@
-@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1')
+@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1', initClass=false)
 
 import com.theokanning.openai.OpenAiService
 import com.theokanning.openai.completion.CompletionRequest
@@ -20,5 +20,5 @@ CompletionRequest completionRequest = CompletionRequest.builder()
         .user("russ.danner@craftercms.com")
         .maxTokens(100)
         .build()
-                
+
 return service.createCompletion(completionRequest).getChoices()

--- a/delivery/scripts/rest/plugins/org/rd/plugin/openai/openai/gentext.get.groovy
+++ b/delivery/scripts/rest/plugins/org/rd/plugin/openai/openai/gentext.get.groovy
@@ -1,5 +1,4 @@
-@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1')
-
+@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1', initClass=false)
 
 import com.theokanning.openai.OpenAiService
 import com.theokanning.openai.completion.CompletionRequest
@@ -21,5 +20,5 @@ CompletionRequest completionRequest = CompletionRequest.builder()
         .user("russ.danner@craftercms.com")
         .maxTokens(100)
         .build()
-                
+
 return service.createCompletion(completionRequest).getChoices()

--- a/delivery/scripts/rest/plugins/org/rd/plugin/textgen/textgen/gentext.get.groovy
+++ b/delivery/scripts/rest/plugins/org/rd/plugin/textgen/textgen/gentext.get.groovy
@@ -1,4 +1,4 @@
-@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1')
+@Grab(group='com.theokanning.openai-gpt3-java', module='client', version='0.8.1', initClass=false)
 
 import com.theokanning.openai.OpenAiService
 import com.theokanning.openai.completion.CompletionRequest
@@ -20,5 +20,5 @@ CompletionRequest completionRequest = CompletionRequest.builder()
         .user("russ.danner@craftercms.com")
         .maxTokens(100)
         .build()
-                
+
 return service.createCompletion(completionRequest).getChoices()


### PR DESCRIPTION
We may want to download the library at runtime so that the API works without a restart after copying the plugin.